### PR TITLE
HOTFIX: ajuste directorio Album por album y ruta main activity en Manifesto

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:theme="@style/Theme.AppVinilos"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name="com.miso.appvinilos.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.AppVinilos">

--- a/app/src/main/java/com/miso/appvinilos/Albums/model/Album.kt
+++ b/app/src/main/java/com/miso/appvinilos/Albums/model/Album.kt
@@ -1,4 +1,0 @@
-package com.miso.appvinilos.Albums.model
-
-// data class Album()
-

--- a/app/src/main/java/com/miso/appvinilos/Albums/network/NetworkServiceAdapterAlbums.kt
+++ b/app/src/main/java/com/miso/appvinilos/Albums/network/NetworkServiceAdapterAlbums.kt
@@ -1,3 +1,0 @@
-package com.miso.appvinilos.Albums.network
-
-// class NetworkServiceAdapter {}

--- a/app/src/main/java/com/miso/appvinilos/Albums/repositories/AlbumRepository.kt
+++ b/app/src/main/java/com/miso/appvinilos/Albums/repositories/AlbumRepository.kt
@@ -1,3 +1,0 @@
-package com.miso.appvinilos.Albums.repositories
-
-// class AlbumRepository {}

--- a/app/src/main/java/com/miso/appvinilos/Albums/ui/AlbumFragment.kt
+++ b/app/src/main/java/com/miso/appvinilos/Albums/ui/AlbumFragment.kt
@@ -1,4 +1,0 @@
-package com.miso.appvinilos.Albums.ui
-
-
-// class AlbumFragment  {}

--- a/app/src/main/java/com/miso/appvinilos/Albums/viewmodels/AlbumViewModel.kt
+++ b/app/src/main/java/com/miso/appvinilos/Albums/viewmodels/AlbumViewModel.kt
@@ -1,3 +1,0 @@
-package com.miso.appvinilos.Albums.viewmodels
-
-// class AlbumViewModel{}

--- a/app/src/main/java/com/miso/appvinilos/MainActivity.kt
+++ b/app/src/main/java/com/miso/appvinilos/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.miso.appvinilos.Albums.ui.theme.AppVinilosTheme
+import com.miso.appvinilos.albums.ui.theme.AppVinilosTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/miso/appvinilos/albums/model/Album.kt
+++ b/app/src/main/java/com/miso/appvinilos/albums/model/Album.kt
@@ -1,0 +1,4 @@
+package com.miso.appvinilos.albums.model
+
+// data class Album()
+

--- a/app/src/main/java/com/miso/appvinilos/albums/network/NetworkServiceAdapterAlbums.kt
+++ b/app/src/main/java/com/miso/appvinilos/albums/network/NetworkServiceAdapterAlbums.kt
@@ -1,0 +1,3 @@
+package com.miso.appvinilos.albums.network
+
+// class NetworkServiceAdapter {}

--- a/app/src/main/java/com/miso/appvinilos/albums/repositories/AlbumRepository.kt
+++ b/app/src/main/java/com/miso/appvinilos/albums/repositories/AlbumRepository.kt
@@ -1,0 +1,3 @@
+package com.miso.appvinilos.albums.repositories
+
+// class AlbumRepository {}

--- a/app/src/main/java/com/miso/appvinilos/albums/ui/AlbumFragment.kt
+++ b/app/src/main/java/com/miso/appvinilos/albums/ui/AlbumFragment.kt
@@ -1,0 +1,4 @@
+package com.miso.appvinilos.albums.ui
+
+
+// class AlbumFragment  {}

--- a/app/src/main/java/com/miso/appvinilos/albums/ui/theme/Color.kt
+++ b/app/src/main/java/com/miso/appvinilos/albums/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.miso.appvinilos.Albums.ui.theme
+package com.miso.appvinilos.albums.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/miso/appvinilos/albums/ui/theme/Theme.kt
+++ b/app/src/main/java/com/miso/appvinilos/albums/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.miso.appvinilos.Albums.ui.theme
+package com.miso.appvinilos.albums.ui.theme
 
 import android.app.Activity
 import android.os.Build

--- a/app/src/main/java/com/miso/appvinilos/albums/ui/theme/Type.kt
+++ b/app/src/main/java/com/miso/appvinilos/albums/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.miso.appvinilos.Albums.ui.theme
+package com.miso.appvinilos.albums.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/java/com/miso/appvinilos/albums/viewmodels/AlbumViewModel.kt
+++ b/app/src/main/java/com/miso/appvinilos/albums/viewmodels/AlbumViewModel.kt
@@ -1,0 +1,3 @@
+package com.miso.appvinilos.albums.viewmodels
+
+// class AlbumViewModel{}


### PR DESCRIPTION
se ajusta nombre carpeta Album por album para matener estandar en nombramiento de carpetas

se ajusta la referencia a main activty en manifesto para que compile correctamente la app en su estado actual